### PR TITLE
Add onSizeChanged() to reset the LinearGradient

### DIFF
--- a/library/src/main/java/com/romainpiel/shimmer/ShimmerTextView.java
+++ b/library/src/main/java/com/romainpiel/shimmer/ShimmerTextView.java
@@ -186,6 +186,19 @@ public class ShimmerTextView extends TextView {
             });
         }
     }
+    
+    @Override
+    protected void onSizeChanged(int w, int h, int oldw, int oldh) {
+        super.onSizeChanged(w, h, oldw, oldh);
+
+        resetLinearGradient();
+
+        isSetUp = true;
+
+        if (callback != null) {
+            callback.onSetupAnimation(ShimmerTextView.this);
+        }
+    }
 
     @Override
     protected void onDraw(Canvas canvas) {


### PR DESCRIPTION
When TextView changed visibility from GONE to VISIBLE, should call resetLinearGradient() again.
