### PR TITLE
removed allowBackup flag

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.romainpiel.shimmer">
 
-    <application android:allowBackup="true"
+    <application
         android:label="@string/app_name"
         android:icon="@drawable/ic_launcher"
 >


### PR DESCRIPTION
allowBackup flag shouldn't be used in libraries due to build problems:
https://code.google.com/p/android/issues/detail?id=70073
https://github.com/chrisbanes/PhotoView/issues/199